### PR TITLE
fix #294

### DIFF
--- a/spring-cloud-alibaba-sentinel/pom.xml
+++ b/spring-cloud-alibaba-sentinel/pom.xml
@@ -37,6 +37,12 @@
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-commons</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-alibaba-sentinel-datasource</artifactId>
         </dependency>
 

--- a/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/custom/SentinelCircuitBreakerConfiguration.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/custom/SentinelCircuitBreakerConfiguration.java
@@ -1,0 +1,12 @@
+package org.springframework.cloud.alibaba.sentinel.custom;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author lengleng
+ * <p>
+ * support @EnableCircuitBreaker ,Do nothing
+ */
+@Configuration
+public class SentinelCircuitBreakerConfiguration {
+}

--- a/spring-cloud-alibaba-sentinel/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-sentinel/src/main/resources/META-INF/spring.factories
@@ -2,3 +2,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.alibaba.sentinel.SentinelWebAutoConfiguration,\
 org.springframework.cloud.alibaba.sentinel.endpoint.SentinelEndpointAutoConfiguration,\
 org.springframework.cloud.alibaba.sentinel.custom.SentinelAutoConfiguration
+
+org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker=\
+org.springframework.cloud.alibaba.sentinel.custom.SentinelCircuitBreakerConfiguration
+


### PR DESCRIPTION
1. import   spring-cloud-commons
2. new blank Configuration    SentinelCircuitBreakerConfiguration
3. set up  spring.factories  EnableCircuitBreaker

As the isuue say,@EnableCircuitBreaker annotation doesn't really do anything, it's just an identifier.

This is done to solve the problem of using standard Spring Cloud annotations.