### PR TITLE
fix #276 

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
@@ -113,11 +113,11 @@ Nacos Client 从 Nacos Server 端获取数据时，调用的是此接口 `Config
 
 在 Nacos Config Starter 中，dataId 的拼接格式如下
 
-	${prefix} - ${spring.active.profile} . ${file-extension}
+	${prefix} - ${spring.profiles.active} . ${file-extension}
 
 * `prefix` 默认为 `spring.application.name` 的值，也可以通过配置项 `spring.cloud.nacos.config.prefix`来配置。
 
-* `spring.active.profile` 即为当前环境对应的 profile，详情可以参考 [Spring Boot文档](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html#boot-features-profiles)
+* `spring.profiles.active` 即为当前环境对应的 profile，详情可以参考 [Spring Boot文档](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html#boot-features-profiles)
 
 	**注意，当 activeprofile 为空时，对应的连接符 `-` 也将不存在，dataId 的拼接格式变成 `${prefix}`.`${file-extension}`**
 

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
@@ -114,11 +114,11 @@ Nacos Client gets data from Nacos Server through this method. `ConfigService.get
 
 In Nacos Config Starter, the splicing format of dataId is as follows
 
-	${prefix} - ${spring.active.profile} . ${file-extension}
+	${prefix} - ${spring.profiles.active} . ${file-extension}
 
 * `prefix` default value is `spring.application.name` value, which can also be configured via the configuration item `spring.cloud.nacos.config.prefix`.
 
-* `spring.active.profile` is the profile corresponding to the current environment. For details, please refer to [Spring Boot Doc](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html#boot-features-profiles)
+* `spring.profiles.active` is the profile corresponding to the current environment. For details, please refer to [Spring Boot Doc](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html#boot-features-profiles)
 
 	**Note: when the activeprofile is empty, the corresponding connector `-` will also not exist, and the splicing format of the dataId becomes `${prefix}`.`${file-extension}`**
 


### PR DESCRIPTION
I saw Nacos code  method of getting the dataId.  
```
environment.getActiveProfiles()
```
So there is an error in the document
Related docs
nacos-config-example/readme-zh.md
nacos-config-example/readme.md