### PR TITLE
feat: sentinel-feign support auto fallback 

### DIFF
--- a/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelFeginAutoFallbackFactory.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelFeginAutoFallbackFactory.java
@@ -1,9 +1,9 @@
 package org.springframework.cloud.alibaba.sentinel.feign;
 
-
-import feign.hystrix.FallbackFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import feign.hystrix.FallbackFactory;
 
 /**
  * @author lengleng
@@ -11,19 +11,20 @@ import org.slf4j.LoggerFactory;
  * sentinel auto fallback，also cglib unified return value
  */
 public final class SentinelFeginAutoFallbackFactory<T> implements FallbackFactory<T> {
-    private static final Logger logger = LoggerFactory.getLogger(SentinelFeginAutoFallbackFactory.class);
-    static final SentinelFeginAutoFallbackFactory INSTANCE = new SentinelFeginAutoFallbackFactory();
+	private static final Logger logger = LoggerFactory
+			.getLogger(SentinelFeginAutoFallbackFactory.class);
+	static final SentinelFeginAutoFallbackFactory INSTANCE = new SentinelFeginAutoFallbackFactory();
 
-    @SuppressWarnings("unchecked")
-    T create(final Class<?> type, final Throwable cause) {
-        logger.error("Fallback class:[{}] message:[{}]",
-                type.getName(), cause.getMessage());
-        return null;
-    }
+	@SuppressWarnings("unchecked")
+	T create(final Class<?> type, final Throwable cause) {
+		logger.error("Fallback class:[{}] message:[{}]", type.getName(),
+				cause.getMessage());
+		return null;
+	}
 
-    @Override
-    public T create(Throwable cause) {
-        logger.error("Fallback message:[{}]", cause.getMessage());
-        return null;
-    }
+	@Override
+	public T create(Throwable cause) {
+		logger.error("Fallback message:[{}]", cause.getMessage());
+		return null;
+	}
 }

--- a/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelFeginAutoFallbackFactory.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelFeginAutoFallbackFactory.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.alibaba.sentinel.feign;
+
+
+import feign.hystrix.FallbackFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author lengleng
+ * <p>
+ * sentinel auto fallback，also cglib unified return value
+ */
+public final class SentinelFeginAutoFallbackFactory<T> implements FallbackFactory<T> {
+    private static final Logger logger = LoggerFactory.getLogger(SentinelFeginAutoFallbackFactory.class);
+    static final SentinelFeginAutoFallbackFactory INSTANCE = new SentinelFeginAutoFallbackFactory();
+
+    @SuppressWarnings("unchecked")
+    T create(final Class<?> type, final Throwable cause) {
+        logger.error("Fallback class:[{}] message:[{}]",
+                type.getName(), cause.getMessage());
+        return null;
+    }
+
+    @Override
+    public T create(Throwable cause) {
+        logger.error("Fallback message:[{}]", cause.getMessage());
+        return null;
+    }
+}

--- a/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelInvocationHandler.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelInvocationHandler.java
@@ -16,7 +16,17 @@
 
 package org.springframework.cloud.alibaba.sentinel.feign;
 
-import static feign.Util.checkNotNull;
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import feign.Feign;
+import feign.InvocationHandlerFactory.MethodHandler;
+import feign.MethodMetadata;
+import feign.Target;
+import feign.hystrix.FallbackFactory;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -25,18 +35,7 @@ import java.lang.reflect.Proxy;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.alibaba.csp.sentinel.Entry;
-import com.alibaba.csp.sentinel.EntryType;
-import com.alibaba.csp.sentinel.SphU;
-import com.alibaba.csp.sentinel.Tracer;
-import com.alibaba.csp.sentinel.context.ContextUtil;
-import com.alibaba.csp.sentinel.slots.block.BlockException;
-
-import feign.Feign;
-import feign.InvocationHandlerFactory.MethodHandler;
-import feign.MethodMetadata;
-import feign.Target;
-import feign.hystrix.FallbackFactory;
+import static feign.Util.checkNotNull;
 
 /**
  * {@link InvocationHandler} handle invocation that protected by Sentinel
@@ -45,128 +44,118 @@ import feign.hystrix.FallbackFactory;
  */
 public class SentinelInvocationHandler implements InvocationHandler {
 
-	private final Target<?> target;
-	private final Map<Method, MethodHandler> dispatch;
+    private final Target<?> target;
+    private final Map<Method, MethodHandler> dispatch;
 
-	private FallbackFactory fallbackFactory;
-	private Map<Method, Method> fallbackMethodMap;
+    private FallbackFactory fallbackFactory;
+    private Map<Method, Method> fallbackMethodMap;
 
-	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch,
-			FallbackFactory fallbackFactory) {
-		this.target = checkNotNull(target, "target");
-		this.dispatch = checkNotNull(dispatch, "dispatch");
-		this.fallbackFactory = fallbackFactory;
-		this.fallbackMethodMap = toFallbackMethod(dispatch);
-	}
+    SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch,
+                              FallbackFactory fallbackFactory) {
+        this.target = checkNotNull(target, "target");
+        this.dispatch = checkNotNull(dispatch, "dispatch");
+        this.fallbackFactory = fallbackFactory;
+        this.fallbackMethodMap = toFallbackMethod(dispatch);
+    }
 
-	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch) {
-		this.target = checkNotNull(target, "target");
-		this.dispatch = checkNotNull(dispatch, "dispatch");
-	}
+    SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch) {
+        this.target = checkNotNull(target, "target");
+        this.dispatch = checkNotNull(dispatch, "dispatch");
+        this.fallbackMethodMap = toFallbackMethod(dispatch);
+    }
 
-	@Override
-	public Object invoke(final Object proxy, final Method method, final Object[] args)
-			throws Throwable {
-		if ("equals".equals(method.getName())) {
-			try {
-				Object otherHandler = args.length > 0 && args[0] != null
-						? Proxy.getInvocationHandler(args[0])
-						: null;
-				return equals(otherHandler);
-			}
-			catch (IllegalArgumentException e) {
-				return false;
-			}
-		}
-		else if ("hashCode".equals(method.getName())) {
-			return hashCode();
-		}
-		else if ("toString".equals(method.getName())) {
-			return toString();
-		}
+    @Override
+    public Object invoke(final Object proxy, final Method method, final Object[] args)
+            throws Throwable {
+        if ("equals".equals(method.getName())) {
+            try {
+                Object otherHandler = args.length > 0 && args[0] != null
+                        ? Proxy.getInvocationHandler(args[0])
+                        : null;
+                return equals(otherHandler);
+            } catch (IllegalArgumentException e) {
+                return false;
+            }
+        } else if ("hashCode".equals(method.getName())) {
+            return hashCode();
+        } else if ("toString".equals(method.getName())) {
+            return toString();
+        }
 
-		Object result;
-		MethodHandler methodHandler = this.dispatch.get(method);
-		// only handle by HardCodedTarget
-		if (target instanceof Target.HardCodedTarget) {
-			Target.HardCodedTarget hardCodedTarget = (Target.HardCodedTarget) target;
-			MethodMetadata methodMetadata = SentinelContractHolder.metadataMap
-					.get(method.getDeclaringClass().getName()
-							+ Feign.configKey(method.getDeclaringClass(), method));
-			// resource default is HttpMethod:protocol://url
-			String resourceName = methodMetadata.template().method().toUpperCase() + ":"
-					+ hardCodedTarget.url() + methodMetadata.template().url();
-			Entry entry = null;
-			try {
-				ContextUtil.enter(resourceName);
-				entry = SphU.entry(resourceName, EntryType.OUT, 1, args);
-				result = methodHandler.invoke(args);
-			}
-			catch (Throwable ex) {
-				// fallback handle
-				if (!BlockException.isBlockException(ex)) {
-					Tracer.trace(ex);
-				}
-				if (fallbackFactory != null) {
-					try {
-						Object fallbackResult = fallbackMethodMap.get(method)
-								.invoke(fallbackFactory.create(ex), args);
-						return fallbackResult;
-					}
-					catch (IllegalAccessException e) {
-						// shouldn't happen as method is public due to being an interface
-						throw new AssertionError(e);
-					}
-					catch (InvocationTargetException e) {
-						throw new AssertionError(e.getCause());
-					}
-				}
-				else {
-					// throw exception if fallbackFactory is null
-					throw ex;
-				}
-			}
-			finally {
-				if (entry != null) {
-					entry.exit();
-				}
-				ContextUtil.exit();
-			}
-		}
-		else {
-			// other target type using default strategy
-			result = methodHandler.invoke(args);
-		}
+        Object result;
+        MethodHandler methodHandler = this.dispatch.get(method);
+        // only handle by HardCodedTarget
+        if (target instanceof Target.HardCodedTarget) {
+            Target.HardCodedTarget hardCodedTarget = (Target.HardCodedTarget) target;
+            MethodMetadata methodMetadata = SentinelContractHolder.metadataMap
+                    .get(method.getDeclaringClass().getName()
+                            + Feign.configKey(method.getDeclaringClass(), method));
+            // resource default is HttpMethod:protocol://url
+            String resourceName = methodMetadata.template().method().toUpperCase() + ":"
+                    + hardCodedTarget.url() + methodMetadata.template().url();
+            Entry entry = null;
+            try {
+                ContextUtil.enter(resourceName);
+                entry = SphU.entry(resourceName, EntryType.OUT, 1, args);
+                result = methodHandler.invoke(args);
+            } catch (Throwable ex) {
+                // fallback handle
+                if (!BlockException.isBlockException(ex)) {
+                    Tracer.trace(ex);
+                }
+                if (fallbackFactory == null) {
+                    return SentinelFeginAutoFallbackFactory.INSTANCE.create(target.type(), ex);
+                }
 
-		return result;
-	}
+                Object fallback = fallbackFactory.create(ex);
+                try {
+                    return fallbackMethodMap.get(method).invoke(fallback, args);
+                } catch (IllegalAccessException e) {
+                    // shouldn't happen as method is public due to being an interface
+                    throw new AssertionError(e);
+                } catch (InvocationTargetException e) {
+                    throw new AssertionError(e.getCause());
+                }
+            } finally {
+                if (entry != null) {
+                    entry.exit();
+                }
+                ContextUtil.exit();
+            }
+        } else {
+            // other target type using default strategy
+            result = methodHandler.invoke(args);
+        }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj instanceof SentinelInvocationHandler) {
-			SentinelInvocationHandler other = (SentinelInvocationHandler) obj;
-			return target.equals(other.target);
-		}
-		return false;
-	}
+        return result;
+    }
 
-	@Override
-	public int hashCode() {
-		return target.hashCode();
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof SentinelInvocationHandler) {
+            SentinelInvocationHandler other = (SentinelInvocationHandler) obj;
+            return target.equals(other.target);
+        }
+        return false;
+    }
 
-	@Override
-	public String toString() {
-		return target.toString();
-	}
+    @Override
+    public int hashCode() {
+        return target.hashCode();
+    }
 
-	static Map<Method, Method> toFallbackMethod(Map<Method, MethodHandler> dispatch) {
-		Map<Method, Method> result = new LinkedHashMap<>();
-		for (Method method : dispatch.keySet()) {
-			method.setAccessible(true);
-			result.put(method, method);
-		}
-		return result;
-	}
+    @Override
+    public String toString() {
+        return target.toString();
+    }
+
+    static Map<Method, Method> toFallbackMethod(Map<Method, MethodHandler> dispatch) {
+        Map<Method, Method> result = new LinkedHashMap<>();
+        for (Method method : dispatch.keySet()) {
+            method.setAccessible(true);
+            result.put(method, method);
+        }
+        return result;
+    }
 
 }

--- a/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelInvocationHandler.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/feign/SentinelInvocationHandler.java
@@ -16,17 +16,7 @@
 
 package org.springframework.cloud.alibaba.sentinel.feign;
 
-import com.alibaba.csp.sentinel.Entry;
-import com.alibaba.csp.sentinel.EntryType;
-import com.alibaba.csp.sentinel.SphU;
-import com.alibaba.csp.sentinel.Tracer;
-import com.alibaba.csp.sentinel.context.ContextUtil;
-import com.alibaba.csp.sentinel.slots.block.BlockException;
-import feign.Feign;
-import feign.InvocationHandlerFactory.MethodHandler;
-import feign.MethodMetadata;
-import feign.Target;
-import feign.hystrix.FallbackFactory;
+import static feign.Util.checkNotNull;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -35,7 +25,18 @@ import java.lang.reflect.Proxy;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static feign.Util.checkNotNull;
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+
+import feign.Feign;
+import feign.InvocationHandlerFactory.MethodHandler;
+import feign.MethodMetadata;
+import feign.Target;
+import feign.hystrix.FallbackFactory;
 
 /**
  * {@link InvocationHandler} handle invocation that protected by Sentinel
@@ -44,118 +45,127 @@ import static feign.Util.checkNotNull;
  */
 public class SentinelInvocationHandler implements InvocationHandler {
 
-    private final Target<?> target;
-    private final Map<Method, MethodHandler> dispatch;
+	private final Target<?> target;
+	private final Map<Method, MethodHandler> dispatch;
 
-    private FallbackFactory fallbackFactory;
-    private Map<Method, Method> fallbackMethodMap;
+	private FallbackFactory fallbackFactory;
+	private Map<Method, Method> fallbackMethodMap;
 
-    SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch,
-                              FallbackFactory fallbackFactory) {
-        this.target = checkNotNull(target, "target");
-        this.dispatch = checkNotNull(dispatch, "dispatch");
-        this.fallbackFactory = fallbackFactory;
-        this.fallbackMethodMap = toFallbackMethod(dispatch);
-    }
+	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch,
+			FallbackFactory fallbackFactory) {
+		this.target = checkNotNull(target, "target");
+		this.dispatch = checkNotNull(dispatch, "dispatch");
+		this.fallbackFactory = fallbackFactory;
+		this.fallbackMethodMap = toFallbackMethod(dispatch);
+	}
 
-    SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch) {
-        this.target = checkNotNull(target, "target");
-        this.dispatch = checkNotNull(dispatch, "dispatch");
-        this.fallbackMethodMap = toFallbackMethod(dispatch);
-    }
+	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch) {
+		this.target = checkNotNull(target, "target");
+		this.dispatch = checkNotNull(dispatch, "dispatch");
+		this.fallbackMethodMap = toFallbackMethod(dispatch);
+	}
 
-    @Override
-    public Object invoke(final Object proxy, final Method method, final Object[] args)
-            throws Throwable {
-        if ("equals".equals(method.getName())) {
-            try {
-                Object otherHandler = args.length > 0 && args[0] != null
-                        ? Proxy.getInvocationHandler(args[0])
-                        : null;
-                return equals(otherHandler);
-            } catch (IllegalArgumentException e) {
-                return false;
-            }
-        } else if ("hashCode".equals(method.getName())) {
-            return hashCode();
-        } else if ("toString".equals(method.getName())) {
-            return toString();
-        }
+	@Override
+	public Object invoke(final Object proxy, final Method method, final Object[] args)
+			throws Throwable {
+		if ("equals".equals(method.getName())) {
+			try {
+				Object otherHandler = args.length > 0 && args[0] != null
+						? Proxy.getInvocationHandler(args[0])
+						: null;
+				return equals(otherHandler);
+			}
+			catch (IllegalArgumentException e) {
+				return false;
+			}
+		}
+		else if ("hashCode".equals(method.getName())) {
+			return hashCode();
+		}
+		else if ("toString".equals(method.getName())) {
+			return toString();
+		}
 
-        Object result;
-        MethodHandler methodHandler = this.dispatch.get(method);
-        // only handle by HardCodedTarget
-        if (target instanceof Target.HardCodedTarget) {
-            Target.HardCodedTarget hardCodedTarget = (Target.HardCodedTarget) target;
-            MethodMetadata methodMetadata = SentinelContractHolder.metadataMap
-                    .get(method.getDeclaringClass().getName()
-                            + Feign.configKey(method.getDeclaringClass(), method));
-            // resource default is HttpMethod:protocol://url
-            String resourceName = methodMetadata.template().method().toUpperCase() + ":"
-                    + hardCodedTarget.url() + methodMetadata.template().url();
-            Entry entry = null;
-            try {
-                ContextUtil.enter(resourceName);
-                entry = SphU.entry(resourceName, EntryType.OUT, 1, args);
-                result = methodHandler.invoke(args);
-            } catch (Throwable ex) {
-                // fallback handle
-                if (!BlockException.isBlockException(ex)) {
-                    Tracer.trace(ex);
-                }
-                if (fallbackFactory == null) {
-                    return SentinelFeginAutoFallbackFactory.INSTANCE.create(target.type(), ex);
-                }
+		Object result;
+		MethodHandler methodHandler = this.dispatch.get(method);
+		// only handle by HardCodedTarget
+		if (target instanceof Target.HardCodedTarget) {
+			Target.HardCodedTarget hardCodedTarget = (Target.HardCodedTarget) target;
+			MethodMetadata methodMetadata = SentinelContractHolder.metadataMap
+					.get(method.getDeclaringClass().getName()
+							+ Feign.configKey(method.getDeclaringClass(), method));
+			// resource default is HttpMethod:protocol://url
+			String resourceName = methodMetadata.template().method().toUpperCase() + ":"
+					+ hardCodedTarget.url() + methodMetadata.template().url();
+			Entry entry = null;
+			try {
+				ContextUtil.enter(resourceName);
+				entry = SphU.entry(resourceName, EntryType.OUT, 1, args);
+				result = methodHandler.invoke(args);
+			}
+			catch (Throwable ex) {
+				// fallback handle
+				if (!BlockException.isBlockException(ex)) {
+					Tracer.trace(ex);
+				}
+				if (fallbackFactory == null) {
+					return SentinelFeginAutoFallbackFactory.INSTANCE.create(target.type(),
+							ex);
+				}
 
-                Object fallback = fallbackFactory.create(ex);
-                try {
-                    return fallbackMethodMap.get(method).invoke(fallback, args);
-                } catch (IllegalAccessException e) {
-                    // shouldn't happen as method is public due to being an interface
-                    throw new AssertionError(e);
-                } catch (InvocationTargetException e) {
-                    throw new AssertionError(e.getCause());
-                }
-            } finally {
-                if (entry != null) {
-                    entry.exit();
-                }
-                ContextUtil.exit();
-            }
-        } else {
-            // other target type using default strategy
-            result = methodHandler.invoke(args);
-        }
+				Object fallback = fallbackFactory.create(ex);
+				try {
+					return fallbackMethodMap.get(method).invoke(fallback, args);
+				}
+				catch (IllegalAccessException e) {
+					// shouldn't happen as method is public due to being an interface
+					throw new AssertionError(e);
+				}
+				catch (InvocationTargetException e) {
+					throw new AssertionError(e.getCause());
+				}
+			}
+			finally {
+				if (entry != null) {
+					entry.exit();
+				}
+				ContextUtil.exit();
+			}
+		}
+		else {
+			// other target type using default strategy
+			result = methodHandler.invoke(args);
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof SentinelInvocationHandler) {
-            SentinelInvocationHandler other = (SentinelInvocationHandler) obj;
-            return target.equals(other.target);
-        }
-        return false;
-    }
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof SentinelInvocationHandler) {
+			SentinelInvocationHandler other = (SentinelInvocationHandler) obj;
+			return target.equals(other.target);
+		}
+		return false;
+	}
 
-    @Override
-    public int hashCode() {
-        return target.hashCode();
-    }
+	@Override
+	public int hashCode() {
+		return target.hashCode();
+	}
 
-    @Override
-    public String toString() {
-        return target.toString();
-    }
+	@Override
+	public String toString() {
+		return target.toString();
+	}
 
-    static Map<Method, Method> toFallbackMethod(Map<Method, MethodHandler> dispatch) {
-        Map<Method, Method> result = new LinkedHashMap<>();
-        for (Method method : dispatch.keySet()) {
-            method.setAccessible(true);
-            result.put(method, method);
-        }
-        return result;
-    }
+	static Map<Method, Method> toFallbackMethod(Map<Method, MethodHandler> dispatch) {
+		Map<Method, Method> result = new LinkedHashMap<>();
+		for (Method method : dispatch.keySet()) {
+			method.setAccessible(true);
+			result.put(method, method);
+		}
+		return result;
+	}
 
 }

--- a/spring-cloud-alibaba-sentinel/src/test/java/org/springframework/cloud/alibaba/sentinel/SentinelFeignTests.java
+++ b/spring-cloud-alibaba-sentinel/src/test/java/org/springframework/cloud/alibaba/sentinel/SentinelFeignTests.java
@@ -16,14 +16,11 @@
 
 package org.springframework.cloud.alibaba.sentinel;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,10 +96,8 @@ public class SentinelFeignTests {
 				echoService.echo("test"));
 		assertEquals("Sentinel Feign Client fallbackFactory success", "foo fallback",
 				fooService.echo("test"));
-		assertThatExceptionOfType(Exception.class).isThrownBy(() -> {
-			barService.bar();
-		});
-
+		Assertions.assertThatCode(() -> barService.bar())
+				.doesNotThrowAnyException();
 		assertNotEquals("ToString method invoke was not in SentinelInvocationHandler",
 				echoService.toString(), fooService.toString());
 		assertNotEquals("HashCode method invoke was not in SentinelInvocationHandler",


### PR DESCRIPTION
Many times, the downgrade strategy is not useful, just want to output the log. But still have to write a Fallback class, and  inject into the Spring IOC。

So when @feignclient does not provide fallback, don't throw exceptions, output error logs by default, which is better, do you think?