### PR TITLE
update Nacos version to 0.8.0, support Nacos discovery namespace ,Polish #295, #317

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -19,8 +19,8 @@
     <properties>
         <sentinel.version>1.4.1</sentinel.version>
         <oss.version>3.1.0</oss.version>
-        <nacos.client.version>0.6.2</nacos.client.version>
-        <nacos.config.version>0.6.1</nacos.config.version>
+        <nacos.client.version>0.8.0</nacos.client.version>
+        <nacos.config.version>0.8.0</nacos.config.version>
         <acm.version>1.0.8</acm.version>
         <ans.version>1.0.1</ans.version>
         <aliyun.sdk.version>4.0.1</aliyun.sdk.version>


### PR DESCRIPTION
### Describe what this PR does / why we need it

update Nacos Version to  0.8.0

### Does this pull request fix one issue?

yes, see #295 and #317 

### Describe how you did it

update dependency management's nacos version to 0.8.0

### Describe how to verify it

set `spring.cloud.nacos.discovery.namespace=59414cfa-56c3-44f8-8036-f27527a551aa` in Nacos discovery example's provider, and then find the service registry to specific namespace in Nacos console.

![image](https://user-images.githubusercontent.com/13148364/51881880-d15c8680-23b7-11e9-8c18-4e7c1718d496.png)


### Special notes for reviews

none