### PR TITLE
Fixes #333, make @EnableDiscoveryClient Optional

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-provider-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/ProviderApplication.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-provider-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/ProviderApplication.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
  * @author xiaojing
  */
 @SpringBootApplication
-@EnableDiscoveryClient
 public class ProviderApplication {
 
 	public static void main(String[] args) {

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosDiscoveryAutoConfiguration.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosDiscoveryAutoConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnNacosDiscoveryEnabled
 @ConditionalOnClass(name = "org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent")
 @ConditionalOnProperty(value = "spring.cloud.service-registry.auto-registration.enabled", matchIfMissing = true)
-@AutoConfigureAfter({ AutoServiceRegistrationAutoConfiguration.class })
+@AutoConfigureAfter(AutoServiceRegistrationAutoConfiguration.class)
 public class NacosDiscoveryAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosDiscoveryAutoConfiguration.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosDiscoveryAutoConfiguration.java
@@ -41,9 +41,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnNacosDiscoveryEnabled
 @ConditionalOnClass(name = "org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent")
 @ConditionalOnProperty(value = "spring.cloud.service-registry.auto-registration.enabled", matchIfMissing = true)
-@AutoConfigureBefore({ AutoServiceRegistrationAutoConfiguration.class,
-		NacosDiscoveryClientAutoConfiguration.class })
-@AutoConfigureAfter(AutoServiceRegistrationConfiguration.class)
+@AutoConfigureAfter({ AutoServiceRegistrationAutoConfiguration.class })
 public class NacosDiscoveryAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.springframework.cloud.alibaba.nacos.NacosDiscoveryAutoConfiguration,\
   org.springframework.cloud.alibaba.nacos.ribbon.RibbonNacosAutoConfiguration,\
-  org.springframework.cloud.alibaba.nacos.endpoint.NacosDiscoveryEndpointAutoConfiguration
-org.springframework.cloud.client.discovery.EnableDiscoveryClient=\
-org.springframework.cloud.alibaba.nacos.NacosDiscoveryClientAutoConfiguration
+  org.springframework.cloud.alibaba.nacos.endpoint.NacosDiscoveryEndpointAutoConfiguration,\
+  org.springframework.cloud.alibaba.nacos.NacosDiscoveryClientAutoConfiguration

--- a/spring-cloud-alicloud-ans/src/main/java/org/springframework/cloud/alicloud/ans/AnsAutoConfiguration.java
+++ b/spring-cloud-alicloud-ans/src/main/java/org/springframework/cloud/alicloud/ans/AnsAutoConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.alicloud.ans;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,7 +27,6 @@ import org.springframework.cloud.alicloud.ans.registry.AnsRegistration;
 import org.springframework.cloud.alicloud.ans.registry.AnsServiceRegistry;
 import org.springframework.cloud.alicloud.context.ans.AnsProperties;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationAutoConfiguration;
-import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -44,9 +42,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(name = "org.springframework.boot.web.context.WebServerInitializedEvent")
 @ConditionalOnProperty(value = "spring.cloud.service-registry.auto-registration.enabled", matchIfMissing = true)
 @ConditionalOnAnsEnabled
-@AutoConfigureBefore({ AutoServiceRegistrationAutoConfiguration.class,
-		AnsDiscoveryClientAutoConfiguration.class })
-@AutoConfigureAfter(AutoServiceRegistrationConfiguration.class)
+@AutoConfigureAfter(AutoServiceRegistrationAutoConfiguration.class)
 public class AnsAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-alicloud-ans/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alicloud-ans/src/main/resources/META-INF/spring.factories
@@ -3,6 +3,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.springframework.cloud.alicloud.ans.ribbon.RibbonAnsAutoConfiguration,\
   org.springframework.cloud.alicloud.ans.AnsAutoConfiguration,\
   org.springframework.cloud.alicloud.ans.migrate.MigrateEndpointAutoConfiguration,\
-  org.springframework.cloud.alicloud.ans.migrate.MigrationAutoconfiguration
-org.springframework.cloud.client.discovery.EnableDiscoveryClient=\
+  org.springframework.cloud.alicloud.ans.migrate.MigrationAutoconfiguration,\
   org.springframework.cloud.alicloud.ans.AnsDiscoveryClientAutoConfiguration


### PR DESCRIPTION
### Describe what this PR does / why we need it

make @EnableDiscoveryClient Optional

### Does this pull request fix one issue?

#333 

### Describe how you did it

delete  org.springframework.cloud.client.discovery.EnableDiscoveryClient Configuration in spring.factories , and add @AutoConfigureAfter(AutoServiceRegistrationAutoConfiguration.class) Annotation

### Describe how to verify it
delete @EnableDiscoveryClient in spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-provider-example, and start the application.it works

### Special notes for reviews
none