### PR TITLE
[Example] Add the missing `@EnableDiscoveryClient` annotation

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-provider-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/ProviderApplication.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-provider-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/ProviderApplication.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author xiaojing
  */
 @SpringBootApplication
+@EnableDiscoveryClient
 public class ProviderApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
[nacos-discovery-example] Add the missing `@EnableDiscoveryClient`  annotation


### Describe what this PR does / why we need it
Fix `No instances available for service-provider` 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
