### PR TITLE
Update NacosDiscoveryProperties.java

### DIFF
--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosDiscoveryProperties.java
@@ -149,6 +149,9 @@ public class NacosDiscoveryProperties {
 		}
 
 		serverAddr = Objects.toString(serverAddr, "");
+		if(serverAddr.lastIndexOf("/") != -1) {
+			serverAddr.substring(0,serverAddr.length()-1);
+		}
 		endpoint = Objects.toString(endpoint, "");
 		namespace = Objects.toString(namespace, "");
 		logName = Objects.toString(logName, "");


### PR DESCRIPTION
当配置属性cloud.nacos.discovery.server-addr以 '/' 结束会造成服务提供方无法注册到NacosServer


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
