### PR TITLE
Bug: Fix a bug. issue#471 fescar-example Demo DatabaseConfiguration.j…

### DIFF
--- a/spring-cloud-alibaba-examples/fescar-example/account-service/src/main/java/org/springframework/cloud/alibaba/cloud/examples/DatabaseConfiguration.java
+++ b/spring-cloud-alibaba-examples/fescar-example/account-service/src/main/java/org/springframework/cloud/alibaba/cloud/examples/DatabaseConfiguration.java
@@ -52,7 +52,7 @@ public class DatabaseConfiguration {
 		String password = environment.getProperty("mysql.user.password");
 
 		DruidDataSource druidDataSource = new DruidDataSource();
-		druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName);
+		druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName + "?serverTimezone=UTC");
 		druidDataSource.setUsername(userName);
 		druidDataSource.setPassword(password);
 		druidDataSource.setDriverClassName("com.mysql.jdbc.Driver");

--- a/spring-cloud-alibaba-examples/fescar-example/order-service/src/main/java/org/springframework/cloud/alibaba/cloud/examples/DatabaseConfiguration.java
+++ b/spring-cloud-alibaba-examples/fescar-example/order-service/src/main/java/org/springframework/cloud/alibaba/cloud/examples/DatabaseConfiguration.java
@@ -51,7 +51,7 @@ public class DatabaseConfiguration {
 		String password = env.getProperty("mysql.user.password");
 
 		DruidDataSource druidDataSource = new DruidDataSource();
-		druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName);
+		druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName + "?serverTimezone=UTC");
 		druidDataSource.setUsername(userName);
 		druidDataSource.setPassword(password);
 		druidDataSource.setDriverClassName("com.mysql.jdbc.Driver");

--- a/spring-cloud-alibaba-examples/fescar-example/storage-service/src/main/java/org/springframework/cloud/alibaba/cloud/examples/DatabaseConfiguration.java
+++ b/spring-cloud-alibaba-examples/fescar-example/storage-service/src/main/java/org/springframework/cloud/alibaba/cloud/examples/DatabaseConfiguration.java
@@ -52,7 +52,7 @@ public class DatabaseConfiguration {
 		String password = environment.getProperty("mysql.user.password");
 
 		DruidDataSource druidDataSource = new DruidDataSource();
-		druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName);
+		druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName + "?serverTimezone=UTC");
 		druidDataSource.setUsername(userName);
 		druidDataSource.setPassword(password);
 		druidDataSource.setDriverClassName("com.mysql.jdbc.Driver");


### PR DESCRIPTION

### Describe what this PR does / why we need it
Fix a bug. issue#471escar-example Demo DatabaseConfiguration.java file need to be impoved, or the error will occur .
(Address:https://github.com/spring-cloud-incubator/spring-cloud-alibaba/issues/471)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
        Fixes #471 
### Describe how you did it
         Under the guidance of the thought， change "druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName);" 
	into "druidDataSource.setUrl("jdbc:mysql://" + ip + ":" + port + "/" + dbName + "?serverTimezone=UTC");” in every databaseConfuguration.java 
	file under this fescar-example directory.

### Describe how to verify it
       then re-run the example, bug is free

### Special notes for reviews
Root Cause of the bug is  when using a newer version of MySQL dataase and jdbc jars , the jdbc url need add serverTimezone parameter to jdbc url. And it's known to all, our project is open to the public, configuration need to meet all versions of the database configuration, in some ways, we should better find the smallest atomic configuration unit to meet all the requirements, not just the database configuration.
