### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 # IDE Files #

--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -41,5 +41,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -26,4 +26,4 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at spring-code-of-conduct@pivotal.io . All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org/), version 1.3.0, available at [contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](https://contributor-covenant.org/), version 1.3.0, available at [contributor-covenant.org/version/1/3/0/](https://contributor-covenant.org/version/1/3/0/)

--- a/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-config-custom-solution.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-config-custom-solution.adoc
@@ -3,7 +3,7 @@
 随着社区的回馈，发现 Spring Cloud Alibaba Nacos Config Starter 目前不能完美的来支持多个应用间的一些共享配置。
 在实际的业务场景中应用和共享配置间的关系可能如下图所示：
 
-image::http://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_01.png[]
+image::https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_01.png[]
 
 * 从单个应用的角度来看： 应用可能会有多套(develop/beta/product)发布环境，多套发布环境之间有不同的基础配置，例如数据库。
 * 从多个应用的角度来看：多个应用间可能会有一些共享通用的配置，比如多个应用之间共用一套zookeeper集群。
@@ -31,7 +31,7 @@ spring.application.group=com.alibaba.aliware.edas
 com.alibaba.aliware 这个应用分组(域)，当然也可以属于 com.alibaba.aliware.edas 这个应用分组(域)。
 罗里吧嗦了这么多，目的就是 Data Id 通过以这个分组(域)来命名，从而实现多个应用间在某个分组(域)下的共享配置。如下图所示：
 
-image::http://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_02.png[]
+image::https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_02.png[]
 
 以这种方式来实现多个应用间的配置共享，可以看出他具有天然的局限性。
 
@@ -64,7 +64,7 @@ NOTE: 为了尽可能的和Nacos使用方式(即Data Id 是一个带有额外文
 
 这个时候两个应用(或多个应用)之间共享配置的 Data Id 关系如下图所示：
 
-image::http://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_03.png[]
+image::https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_03.png[]
 
 Spring Boot 提倡约定大于配置。当使用这种方式来实现应用间的共享配置时，我们也继承了Spring Boot的这个优良传统，多个共享配置间的一个优先级的关系我们约定：按照配置出现的先后顺序，即后面的优先级要高于前面的。
 这种方式的优点在于：

--- a/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
@@ -30,7 +30,7 @@ Discovery Starter 也将服务实例自身的一些元数据信息-例如 host�
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>open.source.test</groupId>

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
@@ -30,7 +30,7 @@ The following sample illustrates how to register a service to Nacos.
 ----
 <?xml version="1.0" encoding="UTF-8"? >
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>open.source.test</groupId>

--- a/spring-cloud-alibaba-examples/fescar-example/account-service/src/main/resources/registry.conf
+++ b/spring-cloud-alibaba-examples/fescar-example/account-service/src/main/resources/registry.conf
@@ -27,7 +27,7 @@ config {
   }
   apollo {
     app.id = "fescar-server"
-    apollo.meta = "http://192.168.1.204:8801"
+    apollo.meta = "https://192.168.1.204:8801"
   }
   file {
     name = "file.conf"

--- a/spring-cloud-alibaba-examples/fescar-example/business-service/src/main/resources/registry.conf
+++ b/spring-cloud-alibaba-examples/fescar-example/business-service/src/main/resources/registry.conf
@@ -27,7 +27,7 @@ config {
   }
   apollo {
     app.id = "fescar-server"
-    apollo.meta = "http://192.168.1.204:8801"
+    apollo.meta = "https://192.168.1.204:8801"
   }
   file {
     name = "file.conf"

--- a/spring-cloud-alibaba-examples/fescar-example/order-service/src/main/resources/registry.conf
+++ b/spring-cloud-alibaba-examples/fescar-example/order-service/src/main/resources/registry.conf
@@ -27,7 +27,7 @@ config {
   }
   apollo {
     app.id = "fescar-server"
-    apollo.meta = "http://192.168.1.204:8801"
+    apollo.meta = "https://192.168.1.204:8801"
   }
   file {
     name = "file.conf"

--- a/spring-cloud-alibaba-examples/fescar-example/storage-service/src/main/resources/registry.conf
+++ b/spring-cloud-alibaba-examples/fescar-example/storage-service/src/main/resources/registry.conf
@@ -27,7 +27,7 @@ config {
   }
   apollo {
     app.id = "fescar-server"
-    apollo.meta = "http://192.168.1.204:8801"
+    apollo.meta = "https://192.168.1.204:8801"
   }
   file {
     name = "file.conf"

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
@@ -139,7 +139,7 @@ Nacos Config Starter 默认为所有获取数据成功的 Nacos 的配置项添�
 		
 如果需要对 Bean 进行动态刷新，请参照 Spring 和 Spring Cloud 规范。推荐给类添加 `@RefreshScope` 或 `@ConfigurationProperties ` 注解，
 
-更多详情请参考 [ContextRefresher Java Doc](http://static.javadoc.io/org.springframework.cloud/spring-cloud-context/2.0.0.RELEASE/org/springframework/cloud/context/refresh/ContextRefresher.html)。
+更多详情请参考 [ContextRefresher Java Doc](https://static.javadoc.io/org.springframework.cloud/spring-cloud-context/2.0.0.RELEASE/org/springframework/cloud/context/refresh/ContextRefresher.html)。
 
 	
 

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
@@ -140,7 +140,7 @@ By default, Nacos Config Starter adds a listening function to all Nacos configur
 		
 If you need to dynamically refresh a bean, please refer to the Spring and Spring Cloud specifications. It is recommended to add `@RefreshScope` or `@ConfigurationProperties ` annotations to the class.
 
-Please refer to[ContextRefresher Java Doc](http://static.javadoc.io/org.springframework.cloud/spring-cloud-context/2.0.0.RELEASE/org/springframework/cloud/context/refresh/ContextRefresher.html) for more details. 
+Please refer to[ContextRefresher Java Doc](https://static.javadoc.io/org.springframework.cloud/spring-cloud-context/2.0.0.RELEASE/org/springframework/cloud/context/refresh/ContextRefresher.html) for more details. 
 
 	
 

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme-zh.md
@@ -65,7 +65,7 @@
 
 1. 首先需要获取 Sentinel 控制台，支持直接下载和源码构建两种方式。
 
-	1. 直接下载：[下载 Sentinel 控制台](http://edas-public.oss-cn-hangzhou.aliyuncs.com/install_package/demo/sentinel-dashboard.jar) 
+	1. 直接下载：[下载 Sentinel 控制台](https://edas-public.oss-cn-hangzhou.aliyuncs.com/install_package/demo/sentinel-dashboard.jar) 
 	2. 源码构建：进入 Sentinel [Github 项目页面](https://github.com/alibaba/Sentinel)，将代码 git clone 到本地自行编译打包，[参考此文档](https://github.com/alibaba/Sentinel/tree/master/sentinel-dashboard)。
 
 2. 启动控制台，执行 Java 命令 `java -jar sentinel-dashboard.jar`完成 Sentinel 控制台的启动。

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme.md
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme.md
@@ -54,7 +54,7 @@ Before we start the demo, let's learn how to connect Sentinel to a Spring Cloud 
 
 1. Install Sentinel dashboard by downloading a fatjar or build from source code.
 
-	1. Download: [Download Sentinel Dashboard](http://edas-public.oss-cn-hangzhou.aliyuncs.com/install_package/demo/sentinel-dashboard.jar) 
+	1. Download: [Download Sentinel Dashboard](https://edas-public.oss-cn-hangzhou.aliyuncs.com/install_package/demo/sentinel-dashboard.jar) 
 	2. Build from source code: Get source code by `git clone git@github.com:alibaba/Sentinel.git` from [Github Sentinel](https://github.com/alibaba/Sentinel) and build your code. See [build reference](https://github.com/alibaba/Sentinel/tree/master/sentinel-dashboard) for details.
 
 2. Start the dashboard by running the `java -jar sentinel-dashboard.jar` command.

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/TestController.java
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/TestController.java
@@ -30,7 +30,7 @@ public class TestController {
 
 	@RequestMapping(value = "/template", method = RequestMethod.GET)
 	public String client() {
-		return restTemplate.getForObject("http://www.taobao.com/test", String.class);
+		return restTemplate.getForObject("https://www.taobao.com/test", String.class);
 	}
 
 }

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/resources/flowrule.json
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/resources/flowrule.json
@@ -16,7 +16,7 @@
     "strategy": 0
   },
   {
-    "resource": "GET:http://www.taobao.com",
+    "resource": "GET:https://www.taobao.com",
     "controlBehavior": 0,
     "count": 0,
     "grade": 1,

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-dubbo-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-dubbo-example/readme-zh.md
@@ -6,7 +6,7 @@
 
 [Sentinel](https://github.com/alibaba/Sentinel) 是阿里巴巴开源的分布式系统的流量防卫组件，Sentinel 把流量作为切入点，从流量控制，熔断降级，系统负载保护等多个维度保护服务的稳定性。
 
-[Dubbo](http://dubbo.apache.org/)是一款高性能Java RPC框架，有对应的[SpringBoot工程](https://github.com/apache/incubator-dubbo-spring-boot-project)。
+[Dubbo](https://dubbo.apache.org/)是一款高性能Java RPC框架，有对应的[SpringBoot工程](https://github.com/apache/incubator-dubbo-spring-boot-project)。
 
 本项目专注于Sentinel与Dubbo的整合，关于Sentinel的更多特性可以查看[sentinel-core-example](https://github.com/spring-cloud-incubator/spring-cloud-alibaba/tree/master/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example)。
 

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-dubbo-example/readme.md
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-dubbo-example/readme.md
@@ -5,7 +5,7 @@ This example illustrates how to use Sentinel starter to implement flow control f
 
 [Sentinel](https://github.com/alibaba/Sentinel) is an open-source project of Alibaba. Sentinel takes "traffic flow" as the breakthrough point, and provides solutions in areas such as flow control, concurrency, circuit breaking, and load protection to protect service stability.
 
-[Dubbo](http://dubbo.apache.org/) is a high-performance, java based open source RPC framework.
+[Dubbo](https://dubbo.apache.org/) is a high-performance, java based open source RPC framework.
 
 This example focus on the integration of Sentinel and Dubbo. You can see more features on [sentinel-core-example](https://github.com/spring-cloud-incubator/spring-cloud-alibaba/tree/master/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example).
 

--- a/spring-cloud-alibaba-sentinel/src/test/resources/flowrule.json
+++ b/spring-cloud-alibaba-sentinel/src/test/resources/flowrule.json
@@ -16,7 +16,7 @@
     "strategy": 0
   },
   {
-    "resource": "http://www.taobao.com",
+    "resource": "https://www.taobao.com",
     "controlBehavior": 0,
     "count": 0,
     "grade": 1,

--- a/spring-cloud-alicloud-context/src/test/java/org/springframework/cloud/alicloud/context/oss/OssAutoConfigurationTests.java
+++ b/spring-cloud-alicloud-context/src/test/java/org/springframework/cloud/alicloud/context/oss/OssAutoConfigurationTests.java
@@ -37,7 +37,7 @@ public class OssAutoConfigurationTests {
 			.withConfiguration(AutoConfigurations.of(OssContextAutoConfiguration.class))
 			.withPropertyValues("spring.cloud.alicloud.accessKey=your-ak",
 					"spring.cloud.alicloud.secretKey=your-sk",
-					"spring.cloud.alicloud.oss.endpoint=http://oss-cn-beijing.aliyuncs.com",
+					"spring.cloud.alicloud.oss.endpoint=https://oss-cn-beijing.aliyuncs.com",
 					"spring.cloud.alicloud.oss.config.userAgent=alibaba",
 					"spring.cloud.alicloud.oss.sts.access-key=your-sts-ak",
 					"spring.cloud.alicloud.oss.sts.secret-key=your-sts-sk",
@@ -53,7 +53,7 @@ public class OssAutoConfigurationTests {
 			assertThat(aliCloudProperties.getAccessKey()).isEqualTo("your-ak");
 			assertThat(aliCloudProperties.getSecretKey()).isEqualTo("your-sk");
 			assertThat(ossProperties.getEndpoint())
-					.isEqualTo("http://oss-cn-beijing.aliyuncs.com");
+					.isEqualTo("https://oss-cn-beijing.aliyuncs.com");
 			assertThat(ossProperties.getConfig().getUserAgent()).isEqualTo("alibaba");
 			assertThat(ossProperties.getSts().getAccessKey()).isEqualTo("your-sts-ak");
 			assertThat(ossProperties.getSts().getSecretKey()).isEqualTo("your-sts-sk");
@@ -69,7 +69,7 @@ public class OssAutoConfigurationTests {
 			assertThat(context.getBeanNamesForType(OSS.class)[0]).isEqualTo("ossClient");
 			OSSClient ossClient = (OSSClient) context.getBean(OSS.class);
 			assertThat(ossClient.getEndpoint().toString())
-					.isEqualTo("http://oss-cn-beijing.aliyuncs.com");
+					.isEqualTo("https://oss-cn-beijing.aliyuncs.com");
 			assertThat(ossClient.getClientConfiguration().getUserAgent())
 					.isEqualTo("alibaba");
 			assertThat(
@@ -90,7 +90,7 @@ public class OssAutoConfigurationTests {
 							.isEqualTo("ossClient");
 					OSSClient ossClient = (OSSClient) context.getBean(OSS.class);
 					assertThat(ossClient.getEndpoint().toString())
-							.isEqualTo("http://oss-cn-beijing.aliyuncs.com");
+							.isEqualTo("https://oss-cn-beijing.aliyuncs.com");
 					assertThat(ossClient.getClientConfiguration().getUserAgent())
 							.isEqualTo("alibaba");
 					assertThat(ossClient.getCredentialsProvider().getCredentials()


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://192.168.1.204:8801 (AnnotatedConnectException) with 4 occurrences migrated to:  
  https://192.168.1.204:8801 ([https](https://192.168.1.204:8801) result AnnotatedConnectException).
* [ ] http://oss-cn-beijing.aliyuncs.com (403) with 4 occurrences migrated to:  
  https://oss-cn-beijing.aliyuncs.com ([https](https://oss-cn-beijing.aliyuncs.com) result 403).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://dubbo.apache.org/ with 2 occurrences migrated to:  
  https://dubbo.apache.org/ ([https](https://dubbo.apache.org/) result 200).
* [ ] http://edas-public.oss-cn-hangzhou.aliyuncs.com/install_package/demo/sentinel-dashboard.jar with 2 occurrences migrated to:  
  https://edas-public.oss-cn-hangzhou.aliyuncs.com/install_package/demo/sentinel-dashboard.jar ([https](https://edas-public.oss-cn-hangzhou.aliyuncs.com/install_package/demo/sentinel-dashboard.jar) result 200).
* [ ] http://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_01.png with 1 occurrences migrated to:  
  https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_01.png ([https](https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_01.png) result 200).
* [ ] http://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_02.png with 1 occurrences migrated to:  
  https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_02.png ([https](https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_02.png) result 200).
* [ ] http://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_03.png with 1 occurrences migrated to:  
  https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_03.png ([https](https://edas.oss-cn-hangzhou.aliyuncs.com/sca/sca_shared_03.png) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 2 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://static.javadoc.io/org.springframework.cloud/spring-cloud-context/2.0.0.RELEASE/org/springframework/cloud/context/refresh/ContextRefresher.html with 2 occurrences migrated to:  
  https://static.javadoc.io/org.springframework.cloud/spring-cloud-context/2.0.0.RELEASE/org/springframework/cloud/context/refresh/ContextRefresher.html ([https](https://static.javadoc.io/org.springframework.cloud/spring-cloud-context/2.0.0.RELEASE/org/springframework/cloud/context/refresh/ContextRefresher.html) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/ ([https](https://contributor-covenant.org/) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 2 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://www.taobao.com/test with 1 occurrences migrated to:  
  https://www.taobao.com/test ([https](https://www.taobao.com/test) result 301).
* [ ] http://www.taobao.com with 2 occurrences migrated to:  
  https://www.taobao.com ([https](https://www.taobao.com) result 302).

# Ignored
These URLs were intentionally ignored.

* http://%s:%s/echo/%s with 2 occurrences
* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1:18081/fescar/feign with 1 occurrences
* http://127.0.0.1:18081/fescar/rest with 1 occurrences
* http://127.0.0.1:18082 with 1 occurrences
* http://127.0.0.1:18082/ with 2 occurrences
* http://127.0.0.1:18082/storage/ with 1 occurrences
* http://127.0.0.1:18083 with 1 occurrences
* http://127.0.0.1:18083/actuator/nacos-config with 1 occurrences
* http://127.0.0.1:18083/actuator/nacos-discovery with 2 occurrences
* http://127.0.0.1:18083/actuator/rocketmq-binder with 1 occurrences
* http://127.0.0.1:18083/actuator/sentinel with 1 occurrences
* http://127.0.0.1:18083/acutator/sentinel with 1 occurrences
* http://127.0.0.1:18083/echo-feign/12345 with 2 occurrences
* http://127.0.0.1:18083/echo-rest/1234 with 2 occurrences
* http://127.0.0.1:18083/hello with 1 occurrences
* http://127.0.0.1:18083/nacos_config with 1 occurrences
* http://127.0.0.1:18083/nacos_discovery with 2 occurrences
* http://127.0.0.1:18083/order with 1 occurrences
* http://127.0.0.1:18083/rocketmq_binder with 2 occurrences
* http://127.0.0.1:18083/sentinel with 2 occurrences
* http://127.0.0.1:18083/test with 1 occurrences
* http://127.0.0.1:18084/account with 1 occurrences
* http://127.0.0.1:18084/actuator/nacos-config with 1 occurrences
* http://127.0.0.1:18084/acutator/oss with 2 occurrences
* http://127.0.0.1:18084/acutator/sms-info with 1 occurrences
* http://127.0.0.1:18084/nacos_config with 1 occurrences
* http://127.0.0.1:18084/oss with 2 occurrences
* http://127.0.0.1:18084/sms-info with 1 occurrences
* http://127.0.0.1:18084/user with 4 occurrences
* http://127.0.0.1:18085/nacos/divide?a=6&b=2 with 2 occurrences
* http://127.0.0.1:18085/nacos/echo/hello-world with 2 occurrences
* http://127.0.0.1:18089/ with 1 occurrences
* http://127.0.0.1:28081/actuator/rocketmq-binder with 1 occurrences
* http://127.0.0.1:8080 with 5 occurrences
* http://127.0.0.1:8082/echo/app-name with 2 occurrences
* http://127.0.0.1:8761/eureka/ with 3 occurrences
* http://127.0.0.1:8848/nacos/v1/cs/configs?dataId=nacos-config-example.properties&group=DEFAULT_GROUP&content=user.id=1%0Auser.name=james%0Auser.age=17 with 2 occurrences
* http://127.0.0.1:8848/nacos/v1/cs/configs?dataId=nacos-config-example.properties&group=DEFAULT_GROUP&content=user.id=1%0Auser.name=james%0Auser.age=18 with 2 occurrences
* http://127.0.0.1:8848/nacos/v1/ns/instances?serviceName=service-provider with 2 occurrences
* http://127.0.0.1:port with 1 occurrences
* http://ans-provider/echo/ with 1 occurrences
* http://bar-service/bar with 1 occurrences
* http://dummy/?a with 1 occurrences
* http://dummy/?a&a=1 with 1 occurrences
* http://dummy/?a&a=1&b with 1 occurrences
* http://dummy/?a&a=1&b&b=2 with 1 occurrences
* http://dummy/?a&a=1&b&b=2&b=3 with 1 occurrences
* http://dummy/?d=1 with 1 occurrences
* http://foo-service/echo/ with 1 occurrences
* http://ip:port/actuator/nacos-discovery with 2 occurrences
* http://ip:port/echo/app-name with 2 occurrences
* http://localhost with 1 occurrences
* http://localhost:18084/download with 2 occurrences
* http://localhost:18084/send.do?telphone= with 1 occurrences
* http://localhost:18084/upload with 2 occurrences
* http://localhost:8080 with 6 occurrences
* http://localhost:9090/eureka/ with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 4 occurrences
* http://service-provider/echo/ with 6 occurrences
* http://test-service/echo/ with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 2 occurrences