### PR TITLE
dubbo examples cannot run because nacos port is miss.

### DIFF
--- a/spring-cloud-alibaba-dubbo/src/main/java/org/springframework/cloud/alibaba/dubbo/metadata/RestMethodMetadata.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/org/springframework/cloud/alibaba/dubbo/metadata/RestMethodMetadata.java
@@ -77,7 +77,6 @@ public class RestMethodMetadata {
         this.bodyIndex = methodMetadata.bodyIndex();
         this.headerMapIndex = methodMetadata.headerMapIndex();
         this.queryMapEncoded = methodMetadata.queryMapEncoded();
-        this.queryMapEncoded = methodMetadata.queryMapEncoded();
         this.returnType = getClassName(methodMetadata.returnType());
         this.bodyType = getClassName(methodMetadata.bodyType());
         this.indexToName = methodMetadata.indexToName();

--- a/spring-cloud-alibaba-dubbo/src/main/java/org/springframework/cloud/alibaba/dubbo/registry/AbstractRegistrationFactory.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/org/springframework/cloud/alibaba/dubbo/registry/AbstractRegistrationFactory.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
  */
 public abstract class AbstractRegistrationFactory<R extends Registration> implements RegistrationFactory<R> {
 
+    @Override
     public final R create(URL url, ConfigurableApplicationContext applicationContext) {
         ServiceInstance serviceInstance = createServiceInstance(url, applicationContext);
         return create(serviceInstance, applicationContext);

--- a/spring-cloud-alibaba-dubbo/src/main/java/org/springframework/cloud/alibaba/dubbo/registry/DelegatingRegistration.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/org/springframework/cloud/alibaba/dubbo/registry/DelegatingRegistration.java
@@ -31,7 +31,7 @@ class DelegatingRegistration implements Registration {
 
     private final ServiceInstance delegate;
 
-    public DelegatingRegistration(ServiceInstance delegate) {
+    DelegatingRegistration(ServiceInstance delegate) {
         this.delegate = delegate;
     }
 

--- a/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-consumer-sample/src/main/resources/bootstrap.yaml
+++ b/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-consumer-sample/src/main/resources/bootstrap.yaml
@@ -34,6 +34,7 @@ spring:
         enabled: true
         register-enabled: true
         server-addr: 127.0.0.1:8848
+        port: 8848
 
 ribbon:
   nacos:

--- a/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-provider-sample/src/main/resources/bootstrap.yaml
+++ b/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-provider-sample/src/main/resources/bootstrap.yaml
@@ -31,6 +31,7 @@ spring:
         enabled: true
         register-enabled: true
         server-addr: 127.0.0.1:8848
+        port: 8848
 
 
 ---


### PR DESCRIPTION
### Describe what this PR does / why we need it
dubbo examples cannot run while use nacos 1.0.0RC2 because nacos port is miss.
![image](https://user-images.githubusercontent.com/15199033/55160289-f8f48300-519d-11e9-8d7f-24e95ce2f929.png)
so i added the port

### Does this pull request fix one issue?
no

### Describe how you did it
add nacos port 8848 in bootstrap.yaml
