### PR TITLE
把过时的rocketmq的nameServer的地址配置名称修正为当前使用的配置名称

### DIFF
--- a/spring-cloud-alibaba-examples/rocketmq-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/rocketmq-example/readme-zh.md
@@ -60,7 +60,7 @@ public class RocketMQApplication {
 配置 Binding 信息：
 ```properties
 # 配置rocketmq的nameserver地址
-spring.cloud.stream.rocketmq.binder.namesrv-addr=127.0.0.1:9876
+spring.cloud.stream.rocketmq.binder.name-server=127.0.0.1:9876
 # 定义name为output的binding
 spring.cloud.stream.bindings.output.destination=test-topic
 spring.cloud.stream.bindings.output.content-type=application/json
@@ -125,7 +125,7 @@ server.port=28081
 配置信息如下：
 
 ```properties
-spring.cloud.stream.rocketmq.binder.namesrv-addr=127.0.0.1:9876
+spring.cloud.stream.rocketmq.binder.name-server=127.0.0.1:9876
 
 spring.cloud.stream.bindings.output.destination=test-topic
 spring.cloud.stream.bindings.output.content-type=application/json

--- a/spring-cloud-alibaba-examples/rocketmq-example/readme.md
+++ b/spring-cloud-alibaba-examples/rocketmq-example/readme.md
@@ -56,7 +56,7 @@ public class RocketMQApplication {
 Configure Binding:
 ```properties
 # configure the nameserver of rocketmq
-spring.cloud.stream.rocketmq.binder.namesrv-addr=127.0.0.1:9876
+spring.cloud.stream.rocketmq.binder.name-server=127.0.0.1:9876
 # configure the output binding named output
 spring.cloud.stream.bindings.output.destination=test-topic
 spring.cloud.stream.bindings.output.content-type=application/json
@@ -121,7 +121,7 @@ And using two input bindings to subscribe messages.
 see the configuration below:
 
 ```properties
-spring.cloud.stream.rocketmq.binder.namesrv-addr=127.0.0.1:9876
+spring.cloud.stream.rocketmq.binder.name-server=127.0.0.1:9876
 
 spring.cloud.stream.bindings.output.destination=test-topic
 spring.cloud.stream.bindings.output.content-type=application/json

--- a/spring-cloud-stream-binder-rocketmq/src/test/java/org/springframework/cloud/stream/binder/rocketmq/RocketMQAutoConfigurationTests.java
+++ b/spring-cloud-stream-binder-rocketmq/src/test/java/org/springframework/cloud/stream/binder/rocketmq/RocketMQAutoConfigurationTests.java
@@ -34,7 +34,7 @@ public class RocketMQAutoConfigurationTests {
 			.withConfiguration(
 					AutoConfigurations.of(RocketMQBinderAutoConfiguration.class))
 			.withPropertyValues(
-					"spring.cloud.stream.rocketmq.binder.namesrv-addr=127.0.0.1:9876",
+					"spring.cloud.stream.rocketmq.binder.name-server=127.0.0.1:9876",
 					"spring.cloud.stream.bindings.output.destination=TopicOrderTest",
 					"spring.cloud.stream.bindings.output.content-type=application/json",
 					"spring.cloud.stream.bindings.input1.destination=TopicOrderTest",


### PR DESCRIPTION
把过时的rocketmq的nameServer的地址配置名称修正为当前使用的配置名称

