### PR TITLE
Configuration for looking up config-server URL via nacos discovery

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/pom.xml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>nacos-discovery-example</artifactId>
+        <version>0.9.1.BUILD-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <artifactId>nacos-discovery-with-spring-cloud-config-example</artifactId>
+    <packaging>jar</packaging>
+    <description>Example demonstrating how to use nacos discovery</description>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/GetConfigController.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/GetConfigController.java
@@ -1,0 +1,19 @@
+package org.springframework.cloud.alibaba.cloud.examples;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GetConfigController {
+
+	@Value("${config}")
+	private String config;
+
+	@RequestMapping(value = "/config", method = RequestMethod.GET)
+	public String getConfig() {
+		return config;
+	}
+
+}

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/NacosDiscoverySpringConfigApplication.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/java/org/springframework/cloud/alibaba/cloud/examples/NacosDiscoverySpringConfigApplication.java
@@ -1,0 +1,18 @@
+package org.springframework.cloud.alibaba.cloud.examples;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+/**
+ * @author JevonYang
+ */
+@SpringBootApplication
+@EnableDiscoveryClient
+public class NacosDiscoverySpringConfigApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(NacosDiscoverySpringConfigApplication.class, args);
+	}
+
+}

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/resources/application.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/resources/application.yml
@@ -1,0 +1,1 @@
+config: config-from-yml

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/resources/bootstrap.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example/src/main/resources/bootstrap.yml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: client
+  cloud:
+    nacos:
+      discovery:
+        server-addr: localhost:8848
+    config:
+      discovery:
+        enabled: true

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/pom.xml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/pom.xml
@@ -19,5 +19,6 @@
     <modules>
         <module>nacos-discovery-consumer-example</module>
         <module>nacos-discovery-provider-example</module>
+        <module>nacos-discovery-with-spring-cloud-config-example</module>
     </modules>
 </project>

--- a/spring-cloud-alibaba-nacos-discovery/pom.xml
+++ b/spring-cloud-alibaba-nacos-discovery/pom.xml
@@ -35,6 +35,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-config-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-config-server</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
             <optional>true</optional>

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/discovery/configclient/NacosConfigServerAutoConfiguration.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/discovery/configclient/NacosConfigServerAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.alibaba.nacos.discovery.configclient;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.alibaba.nacos.NacosDiscoveryProperties;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Extra configuration for config server if it happens to be registered with Nacos.
+ *
+ * @author JevonYang
+ */
+@Configuration
+@EnableConfigurationProperties
+@ConditionalOnClass({ NacosDiscoveryProperties.class, ConfigServerProperties.class })
+public class NacosConfigServerAutoConfiguration {
+
+	@Autowired(required = false)
+	private NacosDiscoveryProperties properties;
+
+	@Autowired(required = false)
+	private ConfigServerProperties server;
+
+	@PostConstruct
+	public void init() {
+		if (this.properties == null || this.server == null) {
+			return;
+		}
+		String prefix = this.server.getPrefix();
+		if (StringUtils.hasText(prefix) && !StringUtils
+				.hasText(this.properties.getMetadata().get("configPath"))) {
+			this.properties.getMetadata().put("configPath", prefix);
+		}
+	}
+
+}

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/discovery/configclient/NacosDiscoveryClientConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/discovery/configclient/NacosDiscoveryClientConfigServiceBootstrapConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.alibaba.nacos.discovery.configclient;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.alibaba.nacos.NacosDiscoveryAutoConfiguration;
+import org.springframework.cloud.alibaba.nacos.discovery.NacosDiscoveryClientAutoConfiguration;
+import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Helper for config client that wants to lookup the config server via discovery.
+ *
+ * @author JevonYang
+ */
+@ConditionalOnClass(ConfigServicePropertySourceLocator.class)
+@ConditionalOnProperty(value = "spring.cloud.config.discovery.enabled", matchIfMissing = false)
+@Configuration
+@ImportAutoConfiguration({ NacosDiscoveryClientAutoConfiguration.class,
+		NacosDiscoveryAutoConfiguration.class })
+public class NacosDiscoveryClientConfigServiceBootstrapConfiguration {
+
+}

--- a/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
@@ -2,4 +2,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.springframework.cloud.alibaba.nacos.NacosDiscoveryAutoConfiguration,\
   org.springframework.cloud.alibaba.nacos.ribbon.RibbonNacosAutoConfiguration,\
   org.springframework.cloud.alibaba.nacos.endpoint.NacosDiscoveryEndpointAutoConfiguration,\
-  org.springframework.cloud.alibaba.nacos.discovery.NacosDiscoveryClientAutoConfiguration
+  org.springframework.cloud.alibaba.nacos.discovery.NacosDiscoveryClientAutoConfiguration,\
+  org.springframework.cloud.alibaba.nacos.discovery.configclient.NacosConfigServerAutoConfiguration
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+  org.springframework.cloud.alibaba.nacos.discovery.configclient.NacosDiscoveryClientConfigServiceBootstrapConfiguration  


### PR DESCRIPTION
###  Describe what this PR does / why we need it
Currentlly, spring-cloud-alibaba-nacos-discovery does not support looking up config-server URL via nacos discovery. Support this feature as Consul/Eureka like.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #708 

### Describe how you did it
Add two configurations for looking up config-server URL via nacos discovery.

### Describe how to verify it
example for looking up config-server URL via nacos will be uploaded later. I tried it locally, runs well

here is the link for example:
https://github.com/JevonYang/spring-cloud-alibaba/tree/master/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-with-spring-cloud-config-example